### PR TITLE
Support asynchronous syntax

### DIFF
--- a/codegen_tests/cg_async.ecs
+++ b/codegen_tests/cg_async.ecs
@@ -1,0 +1,149 @@
+# Codegen test: async/await - all syntax forms
+# Compile with: ecs codegen_tests/cg_async.ecs
+
+# === Async function: pure return ===
+async function pure_return()
+    return 42
+end
+
+# === Async function: return with expression ===
+async function compute(x, y)
+    return x * y + 1
+end
+
+# === Async function: yield + return ===
+async function generator(n)
+    foreach i in range(n)
+        yield i * 2
+    end
+    return n
+end
+
+# === Async function: yield without expression ===
+async function bare_yields()
+    yield
+    yield 1
+    yield
+    return "done"
+end
+
+# === Async function: no return (implicit) ===
+async function no_return()
+    var x = 1
+    var y = 2
+end
+
+# === Async function: throw ===
+async function will_throw(msg)
+    throw msg
+    return 0
+end
+
+# === Async function: variadic args ===
+async function variadic(prefix, ...items)
+    foreach it in items
+        yield prefix + it
+    end
+    return items.size
+end
+
+# === Async function: complex body with if/else ===
+async function conditional(x)
+    if x > 0
+        yield "positive"
+        return x
+    else
+        yield "non-positive"
+        return 0
+    end
+end
+
+# === Async function: nested loops ===
+async function nested(n, m)
+    foreach i in range(n)
+        foreach j in range(m)
+            yield {i, j}
+        end
+    end
+    return n * m
+end
+
+# === Async function: await inside (calls another async function) ===
+async function chained(x)
+    var v = await compute(x, 3)
+    return v * 2
+end
+
+# === Usage patterns (for codegen verification) ===
+
+# await func(args)
+var r1 = await compute(10, 2)
+
+# await func()
+var r2 = await pure_return()
+
+# func().get()
+var r3 = compute(1, 2).get()
+
+# func().consume_all()
+var all1 = generator(3).consume_all()
+
+# foreach over async function
+var sum = 0
+foreach val in generator(4)
+    sum += val
+end
+
+# await on stored instance
+var inst = compute(5, 5)
+var r4 = await inst
+
+# op_call on stored instance
+var inst2 = compute(1, 1)
+var r5 = inst2().get()
+
+# === Variadic call ===
+var v1 = variadic("item:", "a", "b", "c")
+var v_all = v1.consume_all()
+
+# === Async lambdas ===
+
+# Async lambda: expression body
+var al1 = async [](x) -> x * 2
+
+# Async lambda: statement body
+var al2 = async [](x) {
+    if x > 0
+        return x
+    else
+        return -x
+    end
+}
+
+# Async lambda: with captures
+var base = 10
+var al3 = async [base](n) -> base + n
+
+# Async lambda: with by-value capture
+var factor = 3
+var al4 = async [=factor](n) {
+    yield factor * n
+    return factor
+}
+
+# Async lambda: no args, no captures
+var al5 = async []() -> "hello"
+
+# === Exception handling ===
+var exc_ok = false
+try
+    var _ = await will_throw("test")
+catch e
+    exc_ok = e == "test"
+end
+
+# === Multiple independent instances ===
+var gen_a = generator(3)
+var gen_b = generator(5)
+var a_data = gen_a.consume_all()
+var b_data = gen_b.consume_all()

--- a/codegen_tests/run.sh
+++ b/codegen_tests/run.sh
@@ -221,6 +221,15 @@ run_test "switch statement generation" \
   --expect 'case ' \
   --expect 'default'
 
+# ---- async/await ----
+run_test "async/await code generation" \
+  "$SCRIPT_DIR/cg_async.ecs" \
+  --expect 'struct __impl_ecs_async_compute extends __impl_ecs\.ecs_async_base' \
+  --expect 'struct __impl_ecs_lambda_impl_1 extends __impl_ecs\.ecs_async_base' \
+  --expect 'function __fiber_body(__ch' \
+  --expect '__ch\.push_back(' \
+  --expect '\.get()'
+
 # ================================================================
 # Summary
 # ================================================================

--- a/csbuild/ecs.json
+++ b/csbuild/ecs.json
@@ -3,7 +3,7 @@
     "Name": "ecs",
     "Info": "Extended CovScript(ECS Lang) Header",
     "Author": "Michael Lee",
-    "Version": "1.4.0",
+    "Version": "1.4.1",
     "Target": "imports/ecs.csp",
     "Dependencies": [
         "sdk_extension"

--- a/csbuild/ecs_bootstrap.json
+++ b/csbuild/ecs_bootstrap.json
@@ -3,7 +3,7 @@
     "Name": "ecs_bootstrap",
     "Info": "Extended CovScript(ECS Lang) Bootstrap",
     "Author": "Michael Lee",
-    "Version": "1.6.0",
+    "Version": "1.7.0",
     "Target": "imports/ecs_bootstrap.csp",
     "Dependencies": [
         "parsergen",

--- a/csbuild/ecs_generator.json
+++ b/csbuild/ecs_generator.json
@@ -3,7 +3,7 @@
     "Name": "ecs_generator",
     "Info": "Extended CovScript(ECS Lang) Generator",
     "Author": "Michael Lee",
-    "Version": "4.0.0b-260716",
+    "Version": "4.1.0.1",
     "Target": "imports/ecs_generator.csp",
     "Dependencies": [
         "parsergen",

--- a/csbuild/ecs_parser.json
+++ b/csbuild/ecs_parser.json
@@ -3,7 +3,7 @@
     "Name": "ecs_parser",
     "Info": "Extended CovScript(ECS Lang) Parser",
     "Author": "Michael Lee",
-    "Version": "1.3.5",
+    "Version": "1.3.6",
     "Target": "imports/ecs_parser.csp",
     "Dependencies": [
         "parsergen",

--- a/imports/ecs.csp
+++ b/imports/ecs.csp
@@ -252,7 +252,7 @@ function init_lambda(...args)
         throw_exception(runtime.exception("Invalid lambda initialization: no function provided."))
     end
     link func = args.pop_front()
-    return param_new(func, args)
+    return move(param_new(func, args))
 end
 
 # -- Slice Extension --

--- a/imports/ecs.csp
+++ b/imports/ecs.csp
@@ -410,16 +410,10 @@ end
 #  Async/Await Infrastructure
 # ============================================================
 
-struct ecs_async_base
+class awaitable
     var __fiber = null
     var __future = null
     var __channel = new array
-
-    function op_call(...args)
-        this.__fiber = fiber.create(this.__fiber_body, args...)
-        this.__future = this.__fiber.get_future()
-        return this
-    end
 
     function get()
         if this.__future == null
@@ -452,6 +446,15 @@ struct ecs_async_base
         var result = new array
         swap(result, this.__channel)
         return result
+    end
+end
+
+struct ecs_async_base
+    function op_call(...args)
+        var inst = new awaitable
+        inst.__fiber = fiber.create(this.__fiber_body, inst.__channel, args...)
+        inst.__future = inst.__fiber.get_future()
+        return move(inst)
     end
 
     function __fiber_body()

--- a/imports/ecs.csp
+++ b/imports/ecs.csp
@@ -252,7 +252,7 @@ function init_lambda(...args)
         throw_exception(runtime.exception("Invalid lambda initialization: no function provided."))
     end
     link func = args.pop_front()
-    return param_new(func, args).call
+    return param_new(func, args)
 end
 
 # -- Slice Extension --
@@ -403,6 +403,59 @@ namespace type_constructor
             throw_exception(param_new(invalid_type, {"Invalid type when construct hash set, require array."}))
         end
         return val.to_hash_set()
+    end
+end
+
+# ============================================================
+#  Async/Await Infrastructure
+# ============================================================
+
+struct ecs_async_base
+    var __fiber = null
+    var __future = null
+    var __channel = new array
+
+    function op_call(...args)
+        this.__fiber = fiber.create(this.__fiber_body, args...)
+        this.__future = this.__fiber.get_future()
+        return this
+    end
+
+    function get()
+        if this.__future == null
+            return null
+        end
+        return this.__future.get()
+    end
+
+    function next()
+        if this.__fiber == null
+            return {null, true}
+        end
+        while this.__channel.empty() && !this.__fiber.is_finished()
+            this.__fiber.resume()
+        end
+        if !this.__channel.empty()
+            return {this.__channel.pop_front(), this.__channel.empty() && this.__fiber.is_finished()}
+        else
+            return {null, true}
+        end
+    end
+
+    function consume_all()
+        if this.__fiber == null
+            return new array
+        end
+        while !this.__fiber.is_finished()
+            this.__fiber.resume()
+        end
+        var result = new array
+        swap(result, this.__channel)
+        return result
+    end
+
+    function __fiber_body()
+        # Override in derived struct.
     end
 end
 

--- a/imports/ecs_bootstrap.csp
+++ b/imports/ecs_bootstrap.csp
@@ -24,6 +24,7 @@ import parsergen, ecs_parser, ecs_generator, codec, regex
 import sdk_extension as sdk
 
 var wrapper_ver = "1.6.0"
+var exit_code = -1  # -1: continue, 0: success, >0: error
 
 function show_version_simple()
 @begin
@@ -66,7 +67,8 @@ class repl_instance
         until line != null
         code_buff.push_back(line)
         if line == "@exit"
-            system.exit(0)
+            exit_code = 0
+            return new array
         end
         line += "\n"
         var lexer = null
@@ -114,7 +116,8 @@ class repl_instance
                                 end
                             end
                             if repl_impl.has_exited()
-                                system.exit(0)
+                                exit_code = 0
+                                return
                             end
                         catch e
                             system.out.println(e.what)
@@ -139,7 +142,7 @@ function show_version()
         "  STD Version: " + ecs_generator.ecs_info.std_version + "\n"
     )
 @end
-    system.exit(0)
+    exit_code = 0
 end
 
 function show_help()
@@ -168,7 +171,7 @@ function show_help()
         "   -i <PATH>     Append import path\n"
     )
 @end
-    system.exit(0)
+    exit_code = 0
 end
 
 var compiler_args = new string
@@ -193,7 +196,8 @@ function process_args(cmd_args)
         switch cmd_args[index]
             default
                 system.out.println("Error: Unknown option \"" + cmd_args[index] + "\"")
-                system.exit(1)
+                exit_code = 1
+                return
             end
             case "-v"
                 show_version()
@@ -236,7 +240,8 @@ function process_args(cmd_args)
             case "-u"
                 if index == cmd_args.size - 1
                     system.out.println("Error: Option \"-u\" not completed. Usage: \"ecs -u <CHARSET>\"")
-                    system.exit(1)
+                    exit_code = 1
+                    return
                 end
                 unicode = cmd_args[++index].toupper()
                 if unicode == "AUTO"
@@ -246,14 +251,16 @@ function process_args(cmd_args)
             case "-i"
                 if index == cmd_args.size - 1
                     system.out.println("Error: Option \"-i\" not completed. Usage: \"ecs -i <PATH>\"")
-                    system.exit(1)
+                    exit_code = 1
+                    return
                 end
                 csx_path = cmd_args[++index]
             end
             case "-o"
                 if index == cmd_args.size - 1
                     system.out.println("Error: Option \"-o\" not completed. Usage: \"ecs -o <PATH>\"")
-                    system.exit(1)
+                    exit_code = 1
+                    return
                 end
                 output = cmd_args[++index]
                 no_run = true
@@ -261,7 +268,8 @@ function process_args(cmd_args)
             case "--"
                 if index == cmd_args.size - 1
                     system.out.println("Error: Option \"--\" not completed. Usage: \"ecs -- <ARGS>\"")
-                    system.exit(1)
+                    exit_code = 1
+                    return
                 end
                 compiler_args = cmd_args[++index]
             end
@@ -337,7 +345,8 @@ function setup_unicode(charset)
     if unicode_ext == null
         system.out.println("Error: unicode extension not installed yet.")
         system.out.println("Run 'cspkg install extension --yes' to enable unicode support.")
-        system.exit(2)
+        exit_code = 2
+        return null
     end
     var cvt_name = charset.toupper()
     if cvt_name == "AUTO"
@@ -345,7 +354,8 @@ function setup_unicode(charset)
     end
     if !codecvt_map.exist(cvt_name)
         system.out.println("Error: unknown unicode charset \"" + cvt_name + "\".")
-        system.exit(1)
+        exit_code = 1
+        return null
     end
     var cvt = codecvt_map.at(cvt_name)(unicode_ext)
     ecs_parser.grammar.lex = ecs_parser.get_lexical([](str)->unicode_ext.build_optimize_wregex(cvt.local2wide(str)))
@@ -357,24 +367,48 @@ function setup_unicode(charset)
     return cvt
 end
 
-function main(cmd_args)
+function run_ecs(cmd_args)
+    # Reset all state for reentrancy
+    compiler_args = ""
+    file_name = ""
+    arguments = ""
+    args_arr = new array
+    executor = "cs "
+    no_hash = false
+    csx_path = null
+    unicode = null
+    minmal = false
+    no_run = false
+    silent = false
+    splash = null
+    output = null
+    csym = false
+    repl = false
+    exit_code = -1
+
     process_args(cmd_args)
+    if exit_code != -1
+        return exit_code
+    end
     if repl
         var instance = new repl_instance
         instance.silent = silent
         if unicode != null
             instance.unicode_cvt = setup_unicode(unicode)
+            if exit_code != -1
+                return exit_code
+            end
         end
         if csx_path != null
             sdk.set_import_path(runtime.get_import_path() + system.path.delimiter + csx_path)
             instance.codegen.ecsx_path = csx_path.split({system.path.delimiter})
         end
         instance.run(args_arr...)
-        system.exit(0)
+        return exit_code != -1 ? exit_code : 0
     end
     if !system.file.exist(file_name) || !match(ext_reg, file_name)
         system.out.println("Error: invalid input file.")
-        system.exit(1)
+        return 1
     end
     var file_hash = null
     if !no_hash
@@ -388,7 +422,7 @@ function main(cmd_args)
                     if name != null && !name.empty()
                         var mtime = ifs.getline().to_number()
                         if mtime == system.file.mtime(file_name)
-                            system.exit(no_run ? 0 : system.run(process_path(executor + compiler_args + " " + name + arguments)))
+                            return no_run ? 0 : system.run(process_path(executor + compiler_args + " " + name + arguments))
                         end
                     end
                 catch e
@@ -400,6 +434,9 @@ function main(cmd_args)
     var parser = new parsergen.generator
     if unicode != null
         parser.unicode_cvt = setup_unicode(unicode)
+        if exit_code != -1
+            return exit_code
+        end
     end
     parser.add_grammar("ecs-lang", ecs_parser.grammar)
     parser.from_file(file_name)
@@ -408,7 +445,7 @@ function main(cmd_args)
             if csx_path != null
                 compiler_args += " -i " + csx_path
             end
-            system.exit(no_run ? 0 : system.run(process_path(executor + compiler_args + " " + file_name + arguments)))
+            return no_run ? 0 : system.run(process_path(executor + compiler_args + " " + file_name + arguments))
         end
         var codegen = new ecs_generator.generator
         if csx_path != null
@@ -441,7 +478,7 @@ function main(cmd_args)
                 if splash != null
                     system.out.println(splash)
                 end
-                system.exit(no_run ? 0 : system.run(process_path(executor + compiler_args + " " + target_name + arguments)))
+                return no_run ? 0 : system.run(process_path(executor + compiler_args + " " + target_name + arguments))
             end
         else
             system.path.mkdir_p("./.ecs_output/")
@@ -464,7 +501,12 @@ function main(cmd_args)
             if splash != null
                 system.out.println(splash)
             end
-            system.exit(no_run ? 0 : system.run(process_path(executor + compiler_args + " " + target_name + arguments)))
+            return no_run ? 0 : system.run(process_path(executor + compiler_args + " " + target_name + arguments))
         end
     end
+    return 0
+end
+
+function main(cmd_args)
+    system.exit(run_ecs(cmd_args))
 end

--- a/imports/ecs_bootstrap.csp
+++ b/imports/ecs_bootstrap.csp
@@ -1,4 +1,4 @@
-# Bootstrap of Extended Covariant Script Generator v1.6.0
+# Bootstrap of Extended Covariant Script Generator v1.7.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ package ecs_bootstrap
 import parsergen, ecs_parser, ecs_generator, codec, regex
 import sdk_extension as sdk
 
-var wrapper_ver = "1.6.0"
+var wrapper_ver = "1.7.0"
 var exit_code = -1  # -1: continue, 0: success, >0: error
 
 function show_version_simple()

--- a/imports/ecs_generator.csp
+++ b/imports/ecs_generator.csp
@@ -40,9 +40,9 @@ package ecs_generator
 # Master
 
 namespace ecs_info
-    constant version = "4.0.0 Cuon alpinus(Unstable) Build 260716"
-    constant std_version = "210607"
-    constant min_runtime = "210508"
+    constant version = "4.1.0 Cuon alpinus(Stable) Build 1"
+    constant std_version = "260702"
+    constant min_runtime = "260702"
 end
 
 import parsergen, ecs

--- a/imports/ecs_generator.csp
+++ b/imports/ecs_generator.csp
@@ -2015,13 +2015,11 @@ class generator
         var idx = 0
         ++idx  # skip "yield"
         if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "expr")
-            print_indent()
-            target.print("this.__channel.push_back(")
+            target.print("__ch.push_back(")
             this.visit_expr(nodes[idx++].nodes)
             println(")", nodes.front.pos)
         else
-            print_indent()
-            println("this.__channel.push_back(null)", nodes.front.pos)
+            println("__ch.push_back(null)", nodes.front.pos)
         end
         print_indent()
         target.print("fiber.yield()")
@@ -2122,9 +2120,8 @@ class generator
         ++indent
         # __fiber_body
         print_indent()
-        target.print("function __fiber_body(" + fiber_args + ") override")
+        target.print("function __fiber_body(__ch" + (fiber_args != "" ? ", " + fiber_args : "") + ") override")
         println("", pos)
-        ++indent
         var saved_async = async_depth
         ++async_depth
         # Visit function body
@@ -2138,7 +2135,6 @@ class generator
             this.visit_stmts(body_nodes[bi++].nodes)
         end
         async_depth = saved_async
-        --indent
         print_indent()
         println("end", pos)
         --indent
@@ -2496,8 +2492,9 @@ class generator
                 end
                 # __fiber_body
                 print_indent()
-                target.print("function __fiber_body(")
+                target.print("function __fiber_body(__ch")
                 if !dat.argument_list.empty()
+                    target.print(", ")
                     var fb_args = new string
                     foreach it in dat.argument_list
                         if it.second.exist("vargs")

--- a/imports/ecs_generator.csp
+++ b/imports/ecs_generator.csp
@@ -61,6 +61,7 @@ struct lambda_type
     var body_stmts = null
     var body_expr = null
     var pos = {0, 0}
+    var is_async = false
 end
 
 struct catch_type
@@ -88,6 +89,9 @@ class generator
     var indent = -1
     var recursion_depth = 0
     constant max_recursion_depth = 500
+    # Async/Await state
+    var async_depth = 0
+    var in_struct_depth = 0
     # Debug Info
     var gen_dbg_info = false
     var dbg_line_map = new array
@@ -205,6 +209,14 @@ class generator
                 matched = true
                 # Recursive Visit using-stmt
                 this.visit_using_stmt(nodes[idx++].nodes)
+            end
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "async-function-stmt")
+                matched = true
+                if in_struct_depth > 0
+                    error(get_pos(nodes[idx].nodes), "'async function' is not allowed inside a struct or class body.")
+                    return
+                end
+                this.visit_async_function_stmt(nodes[idx++].nodes)
             end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "function-stmt")
                 matched = true
@@ -409,10 +421,18 @@ class generator
                 # Recursive Visit control-stmt
                 this.visit_control_stmt(nodes[idx++].nodes)
             end
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "async-function-stmt")
+                matched = true
+                this.visit_async_function_stmt(nodes[idx++].nodes)
+            end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "function-stmt")
                 matched = true
                 # Recursive Visit function-stmt
                 this.visit_function_stmt(nodes[idx++].nodes)
+            end
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "yield-stmt")
+                matched = true
+                this.visit_yield_stmt(nodes[idx++].nodes)
             end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "return-stmt")
                 matched = true
@@ -588,7 +608,9 @@ class generator
         # Visit endl token
         ++idx; println("", nodes.front.pos)
         # Recursive Visit decl-stmts
+        ++in_struct_depth
         this.visit_decl_stmts(nodes[idx++].nodes)
+        --in_struct_depth
         # Visit term "end"
         print_indent()
         println("end", {0, nodes.back.pos[1] - 1})
@@ -813,6 +835,8 @@ class generator
     end
     function visit_lambda_expr(nodes)
         var idx = 0
+        var saved_async = async_depth
+        async_depth = 0
         stack.push_front(new lambda_type)
         stack.front.pos = nodes.front.pos
         # Visit term "["
@@ -881,13 +905,14 @@ class generator
             end
         end
         lambda_list.push_back(current_lambda)
-        target.print(ecs_prefix + "ecs.init_lambda(global.__" + ecs_prefix + "ecs_lambda_impl_" + lambda_list.size + "__")
+        target.print(ecs_prefix + "ecs.init_lambda(global." + ecs_prefix + "ecs_lambda_impl_" + lambda_list.size)
         var capture_str = ", "
         foreach it in current_lambda.capture_list
             capture_str += it.first + ", "
         end
         capture_str.cut(2)
         target.print(capture_str + ")")
+        async_depth = saved_async
     end
     function visit_relat_expr(nodes)
         var idx = 0
@@ -1538,6 +1563,10 @@ class generator
         # Condition
         block
             var matched = false
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "await-expr")
+                matched = true
+                this.visit_await_expr(nodes[idx++].nodes)
+            end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "visit-expr")
                 matched = true
                 # Recursive Visit visit-expr
@@ -1556,15 +1585,12 @@ class generator
     end
     function visit_return_stmt(nodes)
         var idx = 0
-        # Visit term "return"
-        ++idx; target.print("return")
-        # Optional
+        ++idx  # skip "return"
+        target.print("return")
         if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "expr")
             target.print(" ")
-            # Recursive Visit expr
             this.visit_expr(nodes[idx++].nodes)
         end
-        # Recursive Visit endline
         this.visit_endline(nodes[idx++].nodes)
     end
     function visit_while_stmt(nodes)
@@ -1727,6 +1753,10 @@ class generator
                     this.visit_cond_postfix(nodes[idx++].nodes)
                 end
             end
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "async-lambda-expr")
+                matched = true
+                this.visit_async_lambda_expr(nodes[idx++].nodes)
+            end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "lambda-expr")
                 matched = true
                 # Recursive Visit lambda-expr
@@ -1747,6 +1777,10 @@ class generator
                 matched = true
                 # Recursive Visit logic-or-expr
                 this.visit_logic_or_expr(nodes[idx++].nodes)
+            end
+            if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "async-lambda-expr")
+                matched = true
+                this.visit_async_lambda_expr(nodes[idx++].nodes)
             end
             if !matched && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "lambda-expr")
                 matched = true
@@ -1965,6 +1999,172 @@ class generator
         print_indent()
         println("end", {0, nodes.back.pos[1] - 1})
     end
+    # === Async/Await Support ===
+    function visit_await_expr(nodes)
+        var idx = 0
+        ++idx  # skip "await"
+        target.print("(")
+        this.visit_unary_expr(nodes[idx++].nodes)
+        target.print(").get()")
+    end
+    function visit_yield_stmt(nodes)
+        if async_depth <= 0
+            error(get_pos(nodes), "'yield' can only be used inside an async function.")
+            return
+        end
+        var idx = 0
+        ++idx  # skip "yield"
+        if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "expr")
+            print_indent()
+            target.print("this.__channel.push_back(")
+            this.visit_expr(nodes[idx++].nodes)
+            println(")", nodes.front.pos)
+        else
+            print_indent()
+            println("this.__channel.push_back(null)", nodes.front.pos)
+        end
+        print_indent()
+        target.print("fiber.yield()")
+        this.visit_endline(nodes[idx++].nodes)
+    end
+    function visit_async_lambda_expr(nodes)
+        var idx = 0
+        ++idx  # skip "async"
+        stack.push_front(new lambda_type)
+        stack.front.is_async = true
+        stack.front.pos = nodes.front.pos
+        # Visit term "["
+        ++idx
+        # Optional
+        if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "capture-list")
+            # Recursive Visit capture-list
+            this.visit_capture_list(nodes[idx++].nodes)
+        end
+        # Visit term "]"
+        ++idx
+        stack.push_front("function")
+        # Visit term "("
+        ++idx
+        # Optional
+        if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "argument-list")
+            # Recursive Visit argument-list
+            this.visit_argument_list(nodes[idx++].nodes, false)
+        end
+        # Visit term ")"
+        ++idx
+        var arg_list = new array
+        var arg_safety = 0
+        while (typeid stack.front != typeid string || stack.front != "function") && arg_safety < 256
+            arg_list.push_front(stack.front.first : stack.front.second)
+            stack.pop_front()
+            ++arg_safety
+        end
+        if arg_safety >= 256
+            error(get_pos(nodes), "Internal error: lambda argument collection exceeded safety limit (missing sentinel).")
+        end
+        stack.pop_front()
+        stack.front.argument_list := arg_list
+        # Recursive Visit lambda-body
+        this.visit_lambda_body(nodes[idx++].nodes)
+        link current_lambda = stack.front
+        stack.pop_front()
+        lambda_list.push_back(current_lambda)
+        target.print(ecs_prefix + "ecs.init_lambda(global." + ecs_prefix + "ecs_lambda_impl_" + lambda_list.size)
+        var capture_str = ", "
+        foreach it in current_lambda.capture_list
+            capture_str += it.first + ", "
+        end
+        capture_str.cut(2)
+        target.print(capture_str + ")")
+    end
+    function visit_async_function_stmt(nodes)
+        var idx = 0
+        ++idx  # skip "async"
+        ++idx  # skip "function"
+        var func_name = nodes[idx++].data
+        ++idx  # skip "("
+        stack.push_front("function")
+        if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.syntax_tree && nodes[idx].root == "argument-list")
+            this.visit_argument_list(nodes[idx++].nodes, false)
+        end
+        ++idx  # skip ")"
+        if idx < nodes.size && (typeid nodes[idx] == typeid parsergen.token_type && nodes[idx].data == "override")
+            error(get_pos(nodes), "'async function' does not support 'override'.")
+            return
+        end
+        var arg_list = new array
+        var arg_safety = 0
+        while (typeid stack.front != typeid string || stack.front != "function") && arg_safety < 256
+            arg_list.push_front(stack.front.first : stack.front.second)
+            stack.pop_front()
+            ++arg_safety
+        end
+        if arg_safety >= 256
+            error(get_pos(nodes), "Internal error: async function argument collection exceeded safety limit (missing sentinel).")
+        end
+        stack.pop_front()
+        var fiber_args = ""
+        foreach it in arg_list
+            if it.second.exist("vargs")
+                fiber_args += "..." + it.first + ", "
+            else
+                fiber_args += it.first + ", "
+            end
+        end
+        if fiber_args != ""
+            fiber_args.cut(2)
+        end
+        var struct_name = ecs_prefix + "ecs_async_" + func_name
+        var pos = nodes.front.pos
+        # Struct
+        print_indent()
+        println("struct " + struct_name + " extends " + ecs_prefix + "ecs.ecs_async_base", pos)
+        ++indent
+        # __fiber_body
+        print_indent()
+        target.print("function __fiber_body(" + fiber_args + ") override")
+        println("", pos)
+        ++indent
+        var saved_async = async_depth
+        ++async_depth
+        # Visit function body
+        var body_nodes = nodes[idx++].nodes
+        var bi = 0
+        if typeid body_nodes[bi] == typeid parsergen.token_type && body_nodes[bi].data == "{"
+            ++bi  # skip "{"
+            this.visit_stmts(body_nodes[bi++].nodes)
+        else
+            ++bi  # skip endl
+            this.visit_stmts(body_nodes[bi++].nodes)
+        end
+        async_depth = saved_async
+        --indent
+        print_indent()
+        println("end", pos)
+        --indent
+        print_indent()
+        println("end", pos)
+        # Factory function — creates new instance per call
+        print_indent()
+        target.print("function " + func_name + "(" + fiber_args + ")")
+        println("", pos)
+        ++indent
+        print_indent()
+        println("var __inst = new " + struct_name, pos)
+        if fiber_args != ""
+            print_indent()
+            target.print("__inst(" + fiber_args + ")")
+            println("", pos)
+        else
+            print_indent()
+            println("__inst()", pos)
+        end
+        print_indent()
+        println("return __inst", pos)
+        --indent
+        print_indent()
+        println("end", pos)
+    end
     function visit_function_stmt(nodes)
         var idx = 0
         stack.push_front("function")
@@ -2014,8 +2214,11 @@ class generator
         end
         stack.pop_front()
         --indent
-        # Recursive Visit function-body
+        # Recursive Visit function-body (non-async context)
+        var saved_async = async_depth
+        async_depth = 0
         this.visit_function_body(nodes[idx++].nodes)
+        async_depth = saved_async
     end
     function visit_function_body(nodes)
         var idx = 0
@@ -2277,85 +2480,155 @@ class generator
         for i = 0, i < lambda_list.size, ++i
             indent = 1
             link dat = lambda_list[i]
-            println("struct __" + ecs_prefix + "ecs_lambda_impl_" + to_string(lambda_base + i + 1) + "__", dat.pos)
-            foreach it in dat.capture_list
-                print_indent()
-                println("var " + it.first + " = null", dat.pos)
-            end
-            print_indent()
-            target.print("function construct(")
-            if !dat.capture_list.empty()
-                var str = new string
+            if dat.is_async
+                # Async lambda: struct with captures + __fiber_body
+                println("struct " + ecs_prefix + "ecs_lambda_impl_" + to_string(lambda_base + i + 1) + " extends " + ecs_prefix + "ecs.ecs_async_base", dat.pos)
                 foreach it in dat.capture_list
-                    str += "_" + it.first + ", "
+                    print_indent()
+                    println("var " + it.first + " = null", dat.pos)
                 end
-                str.cut(2)
-                target.print(str)
-            end
-            println(")", dat.pos)
-            ++indent
-            foreach it in dat.capture_list
+                # construct() for captures
+                if !dat.capture_list.empty()
+                    print_indent()
+                    target.print("function construct(")
+                    var cap_str = new string
+                    foreach it in dat.capture_list
+                        cap_str += "_" + it.first + ", "
+                    end
+                    cap_str.cut(2)
+                    target.print(cap_str)
+                    println(")", dat.pos)
+                    ++indent
+                    foreach it in dat.capture_list
+                        print_indent()
+                        if it.second
+                            println("this." + it.first + " = _" + it.first, dat.pos)
+                        else
+                            println("this." + it.first + " := _" + it.first, dat.pos)
+                        end
+                    end
+                    --indent
+                    print_indent()
+                    println("end", dat.pos)
+                end
+                # __fiber_body
                 print_indent()
-                if it.second
-                    println("this." + it.first + " = _" + it.first, dat.pos)
-                else
-                    println("this." + it.first + " := _" + it.first, dat.pos)
+                target.print("function __fiber_body(")
+                if !dat.argument_list.empty()
+                    var fb_args = new string
+                    foreach it in dat.argument_list
+                        if it.second.exist("vargs")
+                            fb_args += "..." + it.first + ", "
+                        else
+                            fb_args += it.first + ", "
+                        end
+                    end
+                    fb_args.cut(2)
+                    target.print(fb_args)
                 end
-            end
-            --indent
-            print_indent()
-            println("end", dat.pos)
-            print_indent()
-            target.print("function call(")
-            if !dat.argument_list.empty()
-                var str = new string
+                println(") override", dat.pos)
+                ++indent
+                var saved_async = async_depth
+                ++async_depth
+                if dat.body_stmts != null
+                    foreach it in dat.body_stmts
+                        this.visit_statement(it)
+                    end
+                end
+                if dat.body_expr != null
+                    print_indent()
+                    target.print("return ")
+                    this.visit_cond_expr(dat.body_expr)
+                    println("", dat.pos)
+                end
+                async_depth = saved_async
+                --indent
+                print_indent()
+                println("end", dat.pos)
+                --indent
+                print_indent()
+                println("end", dat.pos)
+            else
+                println("struct " + ecs_prefix + "ecs_lambda_impl_" + to_string(lambda_base + i + 1), dat.pos)
+                foreach it in dat.capture_list
+                    print_indent()
+                    println("var " + it.first + " = null", dat.pos)
+                end
+                print_indent()
+                target.print("function construct(")
+                if !dat.capture_list.empty()
+                    var str = new string
+                    foreach it in dat.capture_list
+                        str += "_" + it.first + ", "
+                    end
+                    str.cut(2)
+                    target.print(str)
+                end
+                println(")", dat.pos)
+                ++indent
+                foreach it in dat.capture_list
+                    print_indent()
+                    if it.second
+                        println("this." + it.first + " = _" + it.first, dat.pos)
+                    else
+                        println("this." + it.first + " := _" + it.first, dat.pos)
+                    end
+                end
+                --indent
+                print_indent()
+                println("end", dat.pos)
+                print_indent()
+                target.print("function op_call(")
+                if !dat.argument_list.empty()
+                    var str = new string
+                    foreach it in dat.argument_list
+                        if it.second.exist("vargs")
+                            str += "..." + it.first + ", "
+                        else
+                            str += it.first + ", "
+                        end
+                    end
+                    str.cut(2)
+                    target.print(str)
+                end
+                println(")", dat.pos)
+                ++indent
+                print_indent()
+                println("link self = this.op_call", dat.pos)
                 foreach it in dat.argument_list
-                    if it.second.exist("vargs")
-                        str += "..." + it.first + ", "
-                    else
-                        str += it.first + ", "
+                    link map = it.second
+                    if map.exist("pass-by-value")
+                        print_indent()
+                        println("context.unlink_var(\"" + it.first + "\")", dat.pos)
+                    end
+                    if map.exist("check-type")
+                        print_indent()
+                        var type_id = get_id_of_visit_expr(map["check-type"])
+                        if type_id != null && ecs.special_type.exist(type_id)
+                            println(ecs_prefix + "ecs.check_type_s(\"" + it.first + "\", " + it.first + ", " + ecs_prefix + "ecs.type_validator.__" + type_id + ")", dat.pos)
+                        else
+                            target.print(ecs_prefix + "ecs.check_type(\"" + it.first + "\", " + it.first + ", ")
+                            this.visit_visit_expr(map["check-type"])
+                            println(")", dat.pos)
+                        end
                     end
                 end
-                str.cut(2)
-                target.print(str)
-            end
-            println(")", dat.pos)
-            ++indent
-            print_indent()
-            println("link self = this.call", dat.pos)
-            foreach it in dat.argument_list
-                link map = it.second
-                if map.exist("pass-by-value")
-                    print_indent()
-                    println("context.unlink_var(\"" + it.first + "\")", dat.pos)
-                end
-                if map.exist("check-type")
-                    print_indent()
-                    var type_id = get_id_of_visit_expr(map["check-type"])
-                    if type_id != null && ecs.special_type.exist(type_id)
-                        println(ecs_prefix + "ecs.check_type_s(\"" + it.first + "\", " + it.first + ", " + ecs_prefix + "ecs.type_validator.__" + type_id + ")", dat.pos)
-                    else
-                        target.print(ecs_prefix + "ecs.check_type(\"" + it.first + "\", " + it.first + ", ")
-                        this.visit_visit_expr(map["check-type"])
-                        println(")", dat.pos)
+                if dat.body_stmts != null
+                    foreach it in dat.body_stmts
+                        this.visit_statement(it)
                     end
                 end
-            end
-            if dat.body_stmts != null
-                foreach it in dat.body_stmts
-                    this.visit_statement(it)
+                if dat.body_expr != null
+                    print_indent()
+                    target.print("return ")
+                    this.visit_cond_expr(dat.body_expr)
+                    println("", dat.pos)
                 end
-            end
-            if dat.body_expr != null
+                --indent
                 print_indent()
-                target.print("return ")
-                this.visit_cond_expr(dat.body_expr)
-                println("", dat.pos)
+                println("end", dat.pos)
+                println("end", dat.pos)
             end
-            --indent
-            print_indent()
-            println("end", dat.pos)
-            println("end", dat.pos)
         end
     end
     function repl_header()
@@ -2369,6 +2642,9 @@ class generator
         slice_ext = false
         indent = -1
         recursion_depth = 0
+        async_depth = 0
+        in_struct_depth = 0
+
         var buff = new iostream.char_buff
         target = buff.get_ostream()
         try
@@ -2379,6 +2655,8 @@ class generator
                 stack = new array
                 indent = -1
                 recursion_depth = 0
+                async_depth = 0
+                in_struct_depth = 0
                 return null
             end
         end
@@ -2393,6 +2671,9 @@ class generator
         slice_ext = false
         indent = -1
         recursion_depth = 0
+        async_depth = 0
+        in_struct_depth = 0
+
         var buff = new iostream.char_buff
         target = buff.get_ostream()
         try

--- a/imports/ecs_generator.csp
+++ b/imports/ecs_generator.csp
@@ -2144,26 +2144,9 @@ class generator
         --indent
         print_indent()
         println("end", pos)
-        # Factory function — creates new instance per call
+        # Instance — callable via op_call
         print_indent()
-        target.print("function " + func_name + "(" + fiber_args + ")")
-        println("", pos)
-        ++indent
-        print_indent()
-        println("var __inst = new " + struct_name, pos)
-        if fiber_args != ""
-            print_indent()
-            target.print("__inst(" + fiber_args + ")")
-            println("", pos)
-        else
-            print_indent()
-            println("__inst()", pos)
-        end
-        print_indent()
-        println("return __inst", pos)
-        --indent
-        print_indent()
-        println("end", pos)
+        println("var " + func_name + " = new " + struct_name, pos)
     end
     function visit_function_stmt(nodes)
         var idx = 0

--- a/imports/ecs_parser.csp
+++ b/imports/ecs_parser.csp
@@ -85,8 +85,10 @@ var covscript_syntax = {
         {syntax.ref("loop-stmt")},
         {syntax.ref("for-stmt")},
         {syntax.ref("foreach-stmt")},
+        {syntax.ref("async-function-stmt")},
         {syntax.ref("control-stmt")},
         {syntax.ref("function-stmt")},
+        {syntax.ref("yield-stmt")},
         {syntax.ref("return-stmt")},
         {syntax.ref("try-stmt")},
         {syntax.ref("throw-stmt")},
@@ -98,6 +100,7 @@ var covscript_syntax = {
         {syntax.ref("namespace-stmt")},
         {syntax.ref("var-stmt")},
         {syntax.ref("using-stmt")},
+        {syntax.ref("async-function-stmt")},
         {syntax.ref("function-stmt")},
         {syntax.ref("class-stmt")}
     )},
@@ -209,6 +212,14 @@ var covscript_syntax = {
         syntax.cond_or({syntax.term("class")}, {syntax.term("struct")}), syntax.token("id"), syntax.optional(syntax.term("extends"), syntax.ref("visit-expr")), syntax.token("endl"),
         syntax.ref("decl-stmts"), syntax.term("end"), syntax.token("endl")
     },
+    "async-function-stmt" : {
+        syntax.term("async"), syntax.term("function"), syntax.token("id"),
+        syntax.term("("), syntax.optional(syntax.ref("argument-list")), syntax.term(")"),
+        syntax.optional(syntax.term("override")), syntax.ref("function-body")
+    },
+    "yield-stmt" : {
+        syntax.term("yield"), syntax.optional(syntax.nlook(syntax.token("endl")), syntax.ref("expr")), syntax.ref("endline")
+    },
     "control-stmt" : {
         syntax.cond_or({syntax.term("break")}, {syntax.term("continue")}), syntax.ref("endline")
     },
@@ -244,6 +255,11 @@ var covscript_syntax = {
         {syntax.term("%=")},
         {syntax.term("^=")}
     )},
+    "async-lambda-expr" : {
+        syntax.term("async"), syntax.term("["), syntax.optional(syntax.ref("capture-list")), syntax.term("]"),
+        syntax.term("("), syntax.optional(syntax.ref("argument-list")), syntax.term(")"),
+        syntax.ref("lambda-body")
+    },
     "lambda-expr" : {
         syntax.term("["), syntax.optional(syntax.ref("capture-list")), syntax.term("]"), syntax.term("("), syntax.optional(syntax.ref("argument-list")), syntax.term(")"), syntax.ref("lambda-body")
     },
@@ -259,16 +275,18 @@ var covscript_syntax = {
         {syntax.term("->"), syntax.ref("cond-expr")}
     )},
     "cond-expr" : {syntax.cond_or(
-        {syntax.ref("logic-or-expr"), syntax.optional(syntax.ref("cond-postfix"))},
-        {syntax.ref("lambda-expr")}
+        {syntax.ref("async-lambda-expr")},
+        {syntax.ref("lambda-expr")},
+        {syntax.ref("logic-or-expr"), syntax.optional(syntax.ref("cond-postfix"))}
     )},
     "cond-postfix" : {syntax.cond_or(
         {syntax.term("?"), syntax.ref("value-expr"), syntax.term(":"), syntax.ref("cond-expr")},
         {syntax.term(":"), syntax.ref("value-expr")}
     )},
     "value-expr" : {syntax.cond_or(
-        {syntax.ref("logic-or-expr")},
-        {syntax.ref("lambda-expr")}
+        {syntax.ref("async-lambda-expr")},
+        {syntax.ref("lambda-expr")},
+        {syntax.ref("logic-or-expr")}
     )},
     "logic-or-expr" : {
         syntax.ref("logic-and-expr"), syntax.optional(syntax.cond_or({syntax.term("||")}, {syntax.term("or")}), syntax.ref("logic-or-expr"))
@@ -309,7 +327,11 @@ var covscript_syntax = {
     "postfix-expr" : {
         syntax.cond_or({syntax.term("++")}, {syntax.term("--")}, {syntax.term("...")}), syntax.optional(syntax.ref("postfix-expr"))
     },
+    "await-expr" : {
+        syntax.term("await"), syntax.ref("unary-expr")
+    },
     "prim-expr" : {syntax.cond_or(
+        {syntax.ref("await-expr")},
         {syntax.ref("visit-expr")},
         {syntax.ref("constant")}
     )},

--- a/unit_tests/test_async.ecs
+++ b/unit_tests/test_async.ecs
@@ -1,0 +1,156 @@
+function assert(condition, msg)
+    if !condition
+        system.out.println("FAIL: " + msg)
+        system.exit(1)
+    end
+end
+
+var passed = 0
+var failed = 0
+
+system.out.println("Test: async/await")
+
+# Test 1: Basic async - await via .get()
+async function compute()
+    return 42
+end
+var result = await compute()
+if result == 42
+    system.out.println("  PASS: async function returns value via await")
+    ++passed
+else
+    system.out.println("  FAIL: async function returns value via await")
+    ++failed
+end
+
+# Test 2: Async with arg - await via .get()
+async function double_val(n)
+    return n * 2
+end
+var r2 = await double_val(21)
+if r2 == 42
+    system.out.println("  PASS: async function with argument")
+    ++passed
+else
+    system.out.println("  FAIL: async function with argument")
+    ++failed
+end
+
+# Test 3: Yield + foreach
+async function count(n)
+    foreach i in range(n)
+        yield i
+    end
+    return n
+end
+var sum = 0
+foreach val in count(5)
+    sum += val
+end
+if sum == 10
+    system.out.println("  PASS: yield + foreach")
+    ++passed
+else
+    system.out.println("  FAIL: yield + foreach")
+    ++failed
+end
+
+# Test 4: consume_all
+async function gen123()
+    yield 1
+    yield 2
+    yield 3
+    return "done"
+end
+var results = gen123().consume_all()
+if results == {1, 2, 3}
+    system.out.println("  PASS: consume_all")
+    ++passed
+else
+    system.out.println("  FAIL: consume_all")
+    ++failed
+end
+
+# Test 5: Exception via await
+async function throw_error()
+    throw "test_error"
+    return 0
+end
+var exc_caught = false
+try
+    var _ = await throw_error()
+catch e
+    exc_caught = true
+    if e == "test_error"
+        system.out.println("  PASS: exception propagates from async function")
+        ++passed
+    else
+        system.out.println("  FAIL: wrong exception message: " + to_string(e))
+        ++failed
+    end
+end
+if !exc_caught
+    system.out.println("  FAIL: exception was not caught from async function")
+    ++failed
+end
+
+# Test 6: Implicit completion
+async function implicit_done()
+    var x = 99
+end
+var imp_result = await implicit_done()
+if imp_result == null
+    system.out.println("  PASS: implicit completion returns null")
+    ++passed
+else
+    system.out.println("  FAIL: expected null, got " + to_string(imp_result))
+    ++failed
+end
+
+# Test 7: await on existing instance
+async function single_use()
+    return "once"
+end
+var su = single_use()
+var su1 = await su
+if su1 == "once"
+    system.out.println("  PASS: first await on instance works")
+    ++passed
+else
+    system.out.println("  FAIL: first await on instance")
+    ++failed
+end
+
+# Test 8: Direct .get() equivalent to await
+var r_direct = double_val(21).get()
+if r_direct == 42
+    system.out.println("  PASS: direct .get() same as await")
+    ++passed
+else
+    system.out.println("  FAIL: direct .get()")
+    ++failed
+end
+
+# Test 9: Exception in direct .get()
+var dth_caught = false
+try
+    var _ = throw_error().get()
+catch e
+    dth_caught = true
+    if e == "test_error"
+        system.out.println("  PASS: exception in .get() propagates")
+        ++passed
+    else
+        system.out.println("  FAIL: wrong exception: " + to_string(e))
+        ++failed
+    end
+end
+if !dth_caught
+    system.out.println("  FAIL: exception was not caught in .get()")
+    ++failed
+end
+
+system.out.println("Test: async/await - " + to_string(passed) + " passed, " + to_string(failed) + " failed")
+if failed > 0
+    system.exit(1)
+end


### PR DESCRIPTION
This pull request introduces several significant improvements and new features to the ECS language toolchain, including foundational async/await infrastructure, enhanced error handling for the bootstrap process, and support for async/await syntax in the generator. It also updates version numbers across multiple components to reflect these additions and improvements.

**Async/Await Feature and Infrastructure:**

* Added a new `ecs_async_base` struct in `imports/ecs.csp` to provide core async/await primitives, including methods for fiber management, result retrieval, and channel consumption. This lays the groundwork for async/await support in ECS code.
* Updated the generator (`imports/ecs_generator.csp`) to recognize and handle `async-function-stmt` and `yield-stmt` syntax, track async context, and enforce restrictions such as disallowing async functions inside structs or classes. [[1]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR92-R94) [[2]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR213-R220) [[3]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR424-R436) [[4]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR611-R613) [[5]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR838-R839) [[6]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfL884-R915) [[7]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfR64)

**Error Handling and Bootstrap Refactor:**

* Refactored the bootstrap process in `imports/ecs_bootstrap.csp` to replace direct `system.exit` calls with an `exit_code` variable, improving testability and reentrancy. The main entry point now returns exit codes instead of exiting immediately, and error handling is more granular throughout argument parsing and Unicode setup. [[1]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L26-R27) [[2]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L69-R71) [[3]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L117-R120) [[4]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L142-R145) [[5]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L171-R174) [[6]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L196-R200) [[7]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L239-R244) [[8]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L249-R272) [[9]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L360-R411) [[10]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L391-R425) [[11]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68R437-R439) [[12]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L411-R448) [[13]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L444-R481) [[14]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L467-R511)

**Version Updates:**

* Bumped version numbers in `ecs`, `ecs_bootstrap`, `ecs_parser`, and `ecs_generator` metadata files and updated corresponding in-source version constants to reflect the new features and changes. [[1]](diffhunk://#diff-854af916af68dc28870a646f987b0fd0d3f19b8da2b31d70f56771238730fd6aL6-R6) [[2]](diffhunk://#diff-e7c933b86bcd05837f12b1005394f372ffd846511f5f2c8f593b31b450f216c6L6-R6) [[3]](diffhunk://#diff-2f8ce83aa7fc6a1749824f87299f8048bd5b494cbcf1cc77cf9ae2c5246f1737L6-R6) [[4]](diffhunk://#diff-ff0632d42afd7ced4f196c4b7982541cf9100e9978ba975d0b012bf2e3f420a0L6-R6) [[5]](diffhunk://#diff-e2c107e0160a9f6d26137a8cd4e84f0717f7a2195e1f6e40b44434b466c6fdbfL43-R45) [[6]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L1-R1) [[7]](diffhunk://#diff-766f43bcbeac5f0f55ca91f43aba52353478f796c6f65d6a24924316165b1a68L26-R27)

**Lambda Handling:**

* Changed `ecs.init_lambda` to return a moved `param_new` object instead of calling it directly, improving lambda initialization semantics.
* Adjusted lambda code generation to use the new naming convention and async context tracking.

These changes collectively modernize the ECS toolchain with async/await support, improve reliability and error reporting, and prepare the codebase for further asynchronous language features.